### PR TITLE
Upgrade to RN master, fix scene rendering bug, fix back gesture action

### DIFF
--- a/app/containers/AppContainer.js
+++ b/app/containers/AppContainer.js
@@ -27,41 +27,38 @@ class AppContainer extends React.Component {
 			<NavigationAnimatedView
 				navigationState={navigationState}
 				style={styles.outerContainer}
-				renderOverlay={(position, layout) => (
-
+				onNavigate={(action) => {
+					if (action.type === 'back') {
+						onBack();
+					}
+				}}
+				renderOverlay={props => (
 					// Also note that we must explicity pass <NavigationHeader /> an onNavigate prop
 					// because we are no longer relying on an onNavigate function being available in
-					// the global context (something NavigationRootContainer would have given us).
+					// the context (something NavigationRootContainer would have given us).
 					<NavigationHeader
-						navigationState={navigationState}
-						position={position}
+						{...props}
 						getTitle={state => state.key}
 						onNavigate={onBack}
 					/>
 				)}
-				renderScene={(state, index, position, layout) => (
-
+				renderScene={props => (
 					// Again, we pass our navigationState from the Redux store to <NavigationCard />.
 					// Finally, we'll render out our scene based on navigationState in _renderScene().
 					<NavigationCard
-						key={state.key}
-						index={index}
-						navigationState={navigationState}
-						position={position}
-						layout={layout}>
-						<View style={styles.container}>
-							{this._renderScene(navigationState)}
-						</View>
-					</NavigationCard>
+						{...props}
+						key={props.scene.navigationState.key}
+						renderScene={this._renderScene}
+					/>
 				)}
 			/>
 		)
 	}
 
-	_renderScene(navigationState) {
-		let { children, index } = navigationState
+	_renderScene({scene}) {
+		const { navigationState } = scene
 		
-		switch(children[index].key) {
+		switch(navigationState.key) {
 		case 'First':
 			return <First />
 		case 'Second':

--- a/app/reducers.js
+++ b/app/reducers.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux'
-import * as NavigationStateUtils from 'NavigationState'
+import * as NavigationStateUtils from 'NavigationStateUtils'
 
 import { NAV_PUSH, NAV_POP, NAV_JUMP_TO_KEY, NAV_JUMP_TO_INDEX, NAV_RESET } from './actions'
 const initialNavState = {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react-native": "^0.21.0",
+    "react-native": "facebook/react-native#master",
     "react-redux": "^4.4.0",
     "redux": "^3.3.1",
     "redux-thunk": "^2.0.1"


### PR DESCRIPTION
NavigationExperimental is still changing pretty quickly, so it may be easier to point to RN master, which already has some differences with RN 0.22

Switched us over to new scene rendering API, and fixes a bug on line 61 where the main navigation state was being used to determine which scene to render for ALL scenes.

This also shows a proper way to handle the back action
